### PR TITLE
ADC_Read: Support multiple ADC reads

### DIFF
--- a/DRIVERS/MSP430/ADC/ADC_Read.c
+++ b/DRIVERS/MSP430/ADC/ADC_Read.c
@@ -33,6 +33,25 @@ void ADC_init_Standard()
         ADC12_B_MULTIPLESAMPLESDISABLE);
 }
 
+void ADC_initMultiple() 
+{
+    ADC12_B_initParam adcParams = {
+        .sampleHoldSignalSourceSelect = ADC12_B_SAMPLEHOLDSOURCE_SC,
+        .clockSourceSelect = ADC12_B_CLOCKSOURCE_SMCLK,
+        .clockSourceDivider = ADC12_B_CLOCKDIVIDER_1,
+        .clockSourcePredivider = ADC12_B_CLOCKPREDIVIDER__1,
+        .internalChannelMap = ADC12_B_NOINTCH
+    };
+    ADC12_B_init(ADC12_B_BASE, &adcParams);
+
+    ADC12_B_enable(ADC12_B_BASE);
+
+    ADC12_B_setupSamplingTimer(ADC12_B_BASE,
+        ADC12_B_CYCLEHOLD_16_CYCLES,
+        ADC12_B_CYCLEHOLD_16_CYCLES,
+        ADC12_B_MULTIPLESAMPLESENABLE);
+}
+
 void ADC_PinSelect(ADC_Pin pin, uint8_t memoryBufferIndex){
     ADC12_B_configureMemoryParam memoryParams = {
         .memoryBufferControlIndex = memoryBufferIndex,

--- a/DRIVERS/MSP430/ADC/ADC_Read.h
+++ b/DRIVERS/MSP430/ADC/ADC_Read.h
@@ -38,6 +38,16 @@ typedef enum{
  ******************************************************************************/
 extern void ADC_init_Standard();
 
+/******************************************************************************
+ * @brief Same as ADC_init_Standard except ADC12_B_MULTIPLESAMPLESENABLE is set.
+ *
+ * This function sets up the ADC driver, configuring it to allow reading multiple 
+ * pins on a pass.
+ *
+ * @return None.
+ ******************************************************************************/
+extern void ADC_initMultiple();
+
 
 /******************************************************************************
  * @brief Configures a pin as an ADC pin and assigns its values to a memory register.


### PR DESCRIPTION
## Description 

Adds support for reading multiple ADCs in a loop. ADC_Init as it stands only initializes one ADC at a time, if you want to read more than one at a time (say in a loop in an IRC), you have to explicitly tell the ADC module. Called an ADC sweep for reference

"Same as ADC_init_Standard except ADC12_B_MULTIPLESAMPLESENABLE is set."

## How to test (if any tests done)
This was tested on the assembled BMS board. If you want to replicate on a dev board, there is only one exposed ADC pin so you have to figure out a way to change the ADC pin you are getting ADC data from. I just did this manually

## Checklist
- [ x] Code Compiles
- [ x] Did you add any comments
- [ x] Did you test it at all ?! Good Boy/Girl
