### PR TITLE
Feature/cdh/spi wrapper

### DIFF
--- a/APP/CDH_App/driver_init.c
+++ b/APP/CDH_App/driver_init.c
@@ -13,7 +13,7 @@
 #include <utils.h>
 #include <hpl_spi_base.h>
 
-struct spi_m_sync_descriptor MRAM_SPI_0;
+#include "SPI0_wrapper.h"
 
 struct i2c_m_sync_desc Mas_I2C_0;
 
@@ -24,29 +24,6 @@ struct usart_sync_descriptor Debug_USART_0;
 struct usart_sync_descriptor LVDS_USART_1;
 
 struct usart_sync_descriptor LVDS2_USART_2;
-
-void MRAM_SPI_0_PORT_init(void)
-{
-
-	gpio_set_pin_function(PD20, MUX_PD20B_SPI0_MISO);
-
-	gpio_set_pin_function(PD21, MUX_PD21B_SPI0_MOSI);
-
-	gpio_set_pin_function(PD22, MUX_PD22B_SPI0_SPCK);
-}
-
-void MRAM_SPI_0_CLOCK_init(void)
-{
-	_pmc_enable_periph_clock(ID_SPI0);
-}
-
-void MRAM_SPI_0_init(void)
-{
-	MRAM_SPI_0_CLOCK_init();
-	spi_m_sync_set_func_ptr(&MRAM_SPI_0, _spi_get_spi_m_sync());
-	spi_m_sync_init(&MRAM_SPI_0, SPI0);
-	MRAM_SPI_0_PORT_init();
-}
 
 void Mas_I2C_0_PORT_init(void)
 {
@@ -194,8 +171,8 @@ void system_init(void)
 
 	gpio_set_pin_pull_mode(LED0, GPIO_PULL_UP);
 
-	MRAM_SPI_0_init();
-
+	SPI0_init();
+	
 	Mas_I2C_0_init();
 
 	Red_I2C_2_init();

--- a/APP/CDH_App/driver_init.h
+++ b/APP/CDH_App/driver_init.h
@@ -36,8 +36,6 @@ extern "C" {
 #include <hal_usart_sync.h>
 #include <hpl_uart_base.h>
 
-extern struct spi_m_sync_descriptor MRAM_SPI_0;
-
 extern struct i2c_m_sync_desc Mas_I2C_0;
 
 extern struct i2c_m_sync_desc Red_I2C_2;
@@ -47,10 +45,6 @@ extern struct usart_sync_descriptor Debug_USART_0;
 extern struct usart_sync_descriptor LVDS_USART_1;
 
 extern struct usart_sync_descriptor LVDS2_USART_2;
-
-void MRAM_SPI_0_PORT_init(void);
-void MRAM_SPI_0_CLOCK_init(void);
-void MRAM_SPI_0_init(void);
 
 void Mas_I2C_0_CLOCK_init(void);
 void Mas_I2C_0_init(void);

--- a/DRIVERS/CDH_COMMON/wrappers/SPI0_wrapper.c
+++ b/DRIVERS/CDH_COMMON/wrappers/SPI0_wrapper.c
@@ -1,0 +1,85 @@
+#include "SPI0_wrapper.h"
+#include <hpl_spi_base.h>
+#include <hpl_pmc.h>
+#include <atmel_start_pins.h>
+
+struct spi_m_sync_descriptor SPI0_desc;
+
+#define SPI_DEACTIVATE_NEXT 0x8000
+
+static inline void SPI0_pinInit(void)
+{
+	gpio_set_pin_function(PD20, MUX_PD20B_SPI0_MISO);
+	gpio_set_pin_function(PD21, MUX_PD21B_SPI0_MOSI);
+	gpio_set_pin_function(PD22, MUX_PD22B_SPI0_SPCK);
+	gpio_set_pin_function(PD25, MUX_PD25B_SPI0_NPCS1);
+}
+
+static inline void SPI0_clockInit(void)
+{
+	_pmc_enable_periph_clock(ID_SPI0);
+}
+
+// Helper to compute SCBR = MCK / SPI_BAUD (clamped to 1..255)
+static inline uint32_t spi_scbr(uint32_t mck, uint32_t baud)
+{
+	uint32_t div = (mck + baud - 1u) / baud;
+	if (div < 1u)   div = 1u;
+	if (div > 255u) div = 255u;
+	return div;
+}
+
+// Need a custom hardware register initializer because I can't figure out how to generate atmel start spi code that supports NPCS1
+static void SPI0_initHardwareRegisters(void)
+{
+	hri_spi_write_CR_reg(SPI0, SPI_CR_SWRST); // software reset
+	// set NPCS1 disable error handling and set SPI to master. NPCS1 allows us to use PD25 instead of default PB02. PD25 is what CDH board says our CS pin will be and is exposed on our dev boards
+	hri_spi_write_MR_reg(SPI0, SPI_MR_MSTR | SPI_MR_PCS(0x0D) | SPI_MR_MODFDIS ); 
+	uint32_t scbr = spi_scbr(SystemCoreClock, SPI_BAUD_HZ);
+	hri_spi_write_CSR_reg(SPI0, 1, SPI_CSR_BITS_8_BIT | SPI_CSR_SCBR(scbr) | SPI_CSR_NCPHA | SPI_CSR_DLYBS(0) | SPI_CSR_DLYBCT(0) | SPI_CSR_CSAAT);
+}
+
+static inline uint8_t SPI0_transferByte(uint8_t tx)
+{
+	while ((SPI0->SPI_SR & SPI_SR_TDRE) == 0);
+	SPI0->SPI_TDR = SPI_TDR_TD(tx);
+	while ((SPI0->SPI_SR & SPI_SR_RDRF) == 0);
+	return (uint8_t)SPI0->SPI_RDR;
+}
+
+void SPI0_init(void)
+{
+	// Disable pullup on MISO MOSI and SPCK
+	PIOD->PIO_PUDR = (PIO_PUDR_P20 | PIO_PUDR_P21 | PIO_PUDR_P22);
+	SPI0_clockInit();
+	// spi_m_sync_transfer uses this for something
+	SPI0_desc.dev.prvt = SPI0;
+	SPI0_initHardwareRegisters();
+	SPI0_pinInit();
+}
+
+void SPI0_transferCustom(const uint8_t* txbuf, uint8_t* rxbuf, size_t txsize, size_t rxsize)
+{
+	int i;
+	for (i = 0; i < txsize; ++i) {
+		SPI0_transferByte(txbuf[i]);
+	}
+	for (i = 0; i < rxsize; ++i) {
+		rxbuf[i] = SPI0_transferByte(0x00);
+	}
+	
+	// This ensures CS only goes high after we're done transferring (last transfer)
+	hri_spi_write_CR_reg(SPI0, SPI_CR_LASTXFER);
+}
+
+// FIXME: This behaves weirdly hence the custom transfer function. We would like to be able to use atmel drivers as much as possible
+void SPI0_transfer(const uint8_t* txbuf, uint8_t* rxbuf, size_t size)
+{
+	struct spi_xfer xfer;
+	xfer.txbuf = txbuf;
+	xfer.rxbuf = rxbuf;
+	xfer.size = size;
+	spi_m_sync_transfer(&SPI0_desc, &xfer);
+	// This ensures CS only goes high after we're done transferring (last transfer)
+	hri_spi_write_CR_reg(SPI0, SPI_CR_LASTXFER);
+}

--- a/DRIVERS/CDH_COMMON/wrappers/SPI0_wrapper.h
+++ b/DRIVERS/CDH_COMMON/wrappers/SPI0_wrapper.h
@@ -1,0 +1,14 @@
+#ifndef SPI0_WRAPPER_H
+#define SPI0_WRAPPER_H
+
+#include <hal_spi_m_sync.h>
+
+#define SPI_BAUD_HZ 100000u
+
+extern struct spi_m_sync_descriptor SPI0_desc;
+
+void SPI0_init(void);
+void SPI0_transfer(const uint8_t* txbuf, uint8_t* rxbuf, size_t size);
+void SPI0_transferCustom(const uint8_t* txbuf, uint8_t* rxbuf, size_t txsize, size_t rxsize);
+
+#endif // SPI0_WRAPPER_H


### PR DESCRIPTION
## Description (tell us what you changes or added or removed please)
Just adds SPI wrapper for SPI0 to the project. This is built on top of https://github.com/scsd-cdh/OBC/pull/61 and is a prerequisite that it is merged first. 

### NOTE -- Kind of Intersting / Justification not using `spi_m_sync_init()`. 

(Don't really have to read this but I thought it was interesting and worth sticking in here)

I couldn't figure out how to get the CS pin to get mapped to the one we need to use (PD25) via atmel start in atmel start. Atmel start just automatically sets hardware CS (automatic CS toggling) and decides to put the CS to a pin we can't use either on the dev boards or on the assembled CDH board. This decision (among others, but we have some control over the other ones via atmel start UI) then generates this macro (hpl_spi.c `SPI_CONFIGURATION(n)` : 45):

```C
#define SPI_CONFIGURATION(n)                                                                                           \
	{                                                                                                                  \
		(n), (uint32_t)(CONF_SPI_##n##_FIFO_DISABLE << 31),                                                            \
		    ((CONF_SPI_##n##_MODE << 0) | (CONF_SPI_##n##_PS << 1) | (CONF_SPI_##n##_PCSDEC << 2)),                    \
		    ((CONF_SPI_##n##_CPOL << 0) | (CONF_SPI_##n##_NCPHA << 1) | (SPI_CSR_BITS(CONF_SPI_##n##_CHSIZE))          \
		     | (SPI_CSR_SCBR(CONF_SPI_##n##_BAUD_RATE)) | (SPI_CSR_DLYBS(CONF_SPI_##n##_DLYBS))                        \
		     | (SPI_CSR_DLYBCT(CONF_SPI_##n##_DLYBCT))),                                                               \
		    (CONF_SPI_##n##_DUMMYBYTE)                                                                                 \
	}
```

This is basically used to store presets for doing register level programming.  I personally don't feel like dealing with this so just initialize those registers manually in code ( instead of calling `spi_m_sync_init()` and use the api for everything else as middleground and for readability where possible (SPI_wrapper.c 33, 47 ).

Also implemented way simplified custom spi transfer (`SPI_transferCustom(...)` because I was having weirdnesses with `spi_m_sync_transfer` . 

## How to test (if any tests done)
<!-- Link to the issue this PR addresses, e.g., closes #123 -->

Just tested with the logic analzer and mram. Plug logic analyzer wires directly in to PD20 (MISO), PD21 (MOSI), PD22 (SPCK), PD25 (CS) and ran this (just gets device ID):
```C
#include <atmel_start.h>
#include "hal_delay.h"
#include "atmel_start_pins.h"
#include "SPI0_wrapper.h"

#define MRAM_RDSR 0x05
#define MRAM_RDID 0x9F

#define MRAM_STATUS_REGISTER_ID_DATA_BYTES 1
#define MRAM_DEVICE_ID_DATA_BYTES 4

int main(void)
{
	/* Initializes MCU, drivers and middleware */
	
	atmel_start_init();
	
	spi_m_sync_enable(&SPI0_desc);
	
	/* Replace with your application code */
	uint8_t tx = 0x9F;
	const uint8_t *txbuf = &tx; 
	uint8_t rxbuf[MRAM_DEVICE_ID_DATA_BYTES];
	while (1) {
		SPI0_transferCustom(txbuf, rxbuf, 1, sizeof(rxbuf));
		delay_ms(250);
	}
}

```
<img width="1777" height="918" alt="image" src="https://github.com/user-attachments/assets/addbf578-2d79-4236-958e-238305b598fc" />



## Checklist
- [x] Code Compiles
- [x] Did you add any comments
- [x] Did you test it at all ?! Good Boy/Girl
