### PR TITLE
BMS: Fix no ack from CDH issue

### DIFF
--- a/APP/BMS/BMS.c
+++ b/APP/BMS/BMS.c
@@ -248,9 +248,7 @@ static void initGPIO()
     P1SEL0 |= BIT6 | BIT7;                    // I2C pins
     P1SEL1 &= ~(BIT6 | BIT7);
 
-    // Disable the GPIO power-on default high-impedance mode to activate
-    // previously configured port settings
-    PM5CTL0 &= ~LOCKLPM5;
+
 
     // Set flag pins
     // MSP430FR5989 Pins 10 through 13 use GPIO_PORT_P5
@@ -455,8 +453,10 @@ static void I2C_Proc_RX_Data(uint8_t data)
 // Hardware initialization. Initializes MSP430 specific device modules for I2C, ADC, GPIO, Clock, and RTC
 static void initHardware()
 {
-    initClockTo16MHz();
     initGPIO();
+    initClockTo16MHz();
+    // Disable the GPIO power-on default high-impedance mode to activate
+    PMM_unlockLPM5();
     initRTC();
     initADCs();
 }


### PR DESCRIPTION
## Description (tell us what you changes or added or removed please)
Moved PMM_unlockLPM5() to below initClockTo16Mhz() and move initClockTo16Mhz() to below initGPIO() not sure why this works but it does

## How to test (if any tests done)
Connect SAMV71 to MSP dev board and do a tinyprotocol request telemetry

<img width="1428" height="883" alt="image" src="https://github.com/user-attachments/assets/feaf1ec8-1a00-4503-8fa6-a8b1138dd6d2" />

samv71 code: 

comsdrive.c:
```C
#include "commsdrive.h"
#include "tinyprotocol.h"

#include "hal_i2c_m_sync.h"
#include "driver_init.h"

static struct io_descriptor *Mas_I2C_0_io;

uint16_t transmitI2C(const uint8_t* buffer, size_t size)
{
	return io_write(Mas_I2C_0_io, buffer, size);
}

 const static struct TINYPROTOCOL_Config protocolConfig =
 {
     .TINYPROTOCOL_WriteBuffer = transmitI2C
 };


void CommsDrive_Init(int16_t slaveAddr)
{
	i2c_m_sync_enable(&Mas_I2C_0);
        i2c_m_sync_set_slaveaddr(&Mas_I2C_0, slaveAddr, I2C_M_SEVEN);
	i2c_m_sync_get_io_descriptor(&Mas_I2C_0, &Mas_I2C_0_io);
	TINYPROTOCOL_Initialize();
}

void CommsDrive_Process(uint8_t* rx_buf, uint32_t size)
{
	TINYPROTOCOL_SendTelemetryRequest(&protocolConfig, 0x01);
}
```
main.c
```C
#include <atmel_start.h>
#include <atmel_start_pins.h>

#include "hal_delay.h"
#include "commsdrive.h"
#include "driver_examples.h"

int main(void)
{
	/* Initializes MCU, drivers and middleware */
	atmel_start_init();
	CommsDrive_Init(0x08);

	/* Replace with your application code */
	uint8_t rx_buf[1];
	while (1) {
		gpio_toggle_pin_level(LED0);
		CommsDrive_Process(rx_buf, 1);
		delay_ms(100);	
	}
}
```

## Checklist
- [x] Code Compiles
- [x] Did you add any comments
- [x] Did you test it at all ?! Good Boy/Girl
