### PR TITLE
CDH: I2C Wrapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ build/
 *.o
 ProjectFiles/CDH/.generated_files/*
 !/.idea/**
+.idea/copilot**
+.idea/editor.xml
+
 /toolchain/
 node_modules/
 !/.github/workflows/**

--- a/.idea/editor.xml
+++ b/.idea/editor.xml
@@ -339,8 +339,6 @@
     <option name="/Default/CodeStyle/CodeFormatting/CppFormatting/WRAP_BEFORE_INVOCATION_RPAR/@EntryValue" value="false" type="bool" />
     <option name="/Default/CodeStyle/CodeFormatting/CppFormatting/WRAP_BEFORE_TERNARY_OPSIGNS/@EntryValue" value="true" type="bool" />
     <option name="/Default/CodeStyle/CodeFormatting/CppFormatting/WRAP_PARAMETERS_STYLE/@EntryValue" value="WRAP_IF_LONG" type="string" />
-    <option name="/Default/CodeStyle/CppIncludeDirective/SortIncludeDirectives/@EntryValue" value="true" type="bool" />
-    <option name="/Default/CodeStyle/CppIncludeDirective/UseAngleBracketsInsteadOfQuotes/@EntryValue" value="WhenPossible" type="string" />
     <option name="/Default/CodeStyle/EditorConfig/EnableClangFormatSupport/@EntryValue" value="false" type="bool" />
   </component>
 </project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -9,5 +9,5 @@
       <file path="$PROJECT_DIR$/toolchain" />
     </excludeRoots>
   </component>
-  <component name="WestSettings"><![CDATA[{}]]></component>
+  <component name="WestSettings">{}</component>
 </project>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,9 @@ add_subdirectory("${PROJECT_SOURCE_DIR}/DRIVERS/SAMV71_DFP/2.4.182")
 add_subdirectory("${PROJECT_SOURCE_DIR}/DRIVERS/SAMV71")
 add_subdirectory("${PROJECT_SOURCE_DIR}/DRIVERS/CDH_COMMON")
 
+# Load middleware
+add_subdirectory("${PROJECT_SOURCE_DIR}/MIDDLEWARE/tinyprotocol")
+
 # Load app
 add_subdirectory("${PROJECT_SOURCE_DIR}/APP/CDH_App")
 

--- a/DRIVERS/CDH_COMMON/CMakeLists.txt
+++ b/DRIVERS/CDH_COMMON/CMakeLists.txt
@@ -1,4 +1,5 @@
-add_library(DRIVER_CDH_COMMON)
+add_library(DRIVER_CDH_COMMON
+        src/I2C0_wrapper.c)
 target_sources(DRIVER_CDH_COMMON
     PUBLIC
         FILE_SET HEADERS
@@ -7,6 +8,7 @@ target_sources(DRIVER_CDH_COMMON
             include/CDH/SPI0_wrapper.h
             include/CDH/pins.h
             include/CDH/driver_init.h
+        include/CDH/I2C0_wrapper.h
 
     PRIVATE
         FILE_SET private_headers
@@ -21,6 +23,7 @@ target_sources(DRIVER_CDH_COMMON
         src/Device_Startup/startup_${BOARD_NAME_LOWER}.c
         src/Device_Startup/system_${BOARD_NAME_LOWER}.c
         src/driver_init.c
+        src/I2C0_wrapper.c
 )
 
 target_include_directories(DRIVER_CDH_COMMON PUBLIC include)

--- a/DRIVERS/CDH_COMMON/include/CDH/I2C0_wrapper.h
+++ b/DRIVERS/CDH_COMMON/include/CDH/I2C0_wrapper.h
@@ -1,0 +1,42 @@
+//
+// Created by EXT-BXK09021 on 11/20/2025.
+//
+
+#ifndef OBC_I2C_TWIHS0_WRAPPER_H
+#define OBC_I2C_TWIHS0_WRAPPER_H
+#include <stdint.h>
+
+/**
+ * @brief Initialize the TWIHS0 I2C master instance.
+ *
+ * Performs clock enable, i2c_m_sync initialization, port configuration,
+ * enables the master, and obtains the IO descriptor.
+ */
+void mas_i2c_0_init(void);
+
+/**
+ * @brief Set the slave address for subsequent I2C operations.
+ * @param slave_addr The 7-bit I2C slave address.
+ */
+void mas_i2c_0_set_slave_addr(int16_t slave_addr);
+
+/**
+ * @brief Write data to the I2C slave device at the specified slave address.
+ * @param slave_addr The 7-bit I2C slave address.
+ * @param p_tx_buffer to write
+ * @param length length of buffer
+ * @return 32 bit return code defined in hal_i2c_m_sync.h
+ */
+int32_t mas_i2c_0_write(uint16_t slave_addr, const uint8_t* p_tx_buffer, uint8_t length);
+
+/**
+ * @brief Read data from the I2C slave device at the specified slave address.
+ * @param slave_addr The 7-bit I2C slave address.
+ * @param p_rx_buffer Buffer to store received data.
+ * @param length Length of data to read.
+ * @return 32 bit return code defined in hal_i2c_m_sync.h
+ */
+int32_t mas_i2c_0_read(int16_t slave_addr, uint8_t* p_rx_buffer, uint8_t length);
+
+#endif // OBC_I2C_TWIHS0_WRAPPER_H
+

--- a/DRIVERS/CDH_COMMON/src/I2C0_wrapper.c
+++ b/DRIVERS/CDH_COMMON/src/I2C0_wrapper.c
@@ -1,0 +1,48 @@
+//
+// Created by EXT-BXK09021 on 11/20/2025.
+//
+
+#include "CDH/I2C0_wrapper.h"
+
+#include "hal_gpio.h"
+#include "hal_i2c_m_sync.h"
+#include "hpl_pmc.h"
+#include "CDH/pins.h"
+
+static struct i2c_m_sync_desc s_i2c_master;
+static struct io_descriptor *p_i2c_io;
+
+void mas_i2c_0_init(void)
+{
+    _pmc_enable_periph_clock(ID_TWIHS0);
+    i2c_m_sync_init(&s_i2c_master, TWIHS0);
+    gpio_set_pin_function(PA4, MUX_PA4A_TWIHS0_TWCK0);
+    gpio_set_pin_function(PA3, MUX_PA3A_TWIHS0_TWD0);
+    i2c_m_sync_enable(&s_i2c_master);
+    i2c_m_sync_get_io_descriptor(&s_i2c_master, &p_i2c_io);
+}
+
+void mas_i2c_0_set_slave_addr(int16_t slave_addr)
+{
+    i2c_m_sync_set_slaveaddr(&s_i2c_master, slave_addr, I2C_M_SEVEN);
+}
+
+int32_t mas_i2c_0_write(uint16_t slave_addr, const uint8_t* p_tx_buffer, uint8_t length)
+{
+    struct _i2c_m_msg msg;
+    msg.addr = slave_addr;
+    msg.buffer = p_tx_buffer;
+    msg.flags = 0; // Not sure why there isn't I2C_M_WR, just checks if the flag is set for read
+    msg.len = length;
+    return i2c_m_sync_transfer(&s_i2c_master, &msg);
+}
+
+int32_t mas_i2c_0_read(int16_t slave_addr, uint8_t* p_rx_buffer, uint8_t length)
+{
+    struct _i2c_m_msg msg;
+    msg.addr = slave_addr;
+    msg.buffer = p_rx_buffer;
+    msg.flags = I2C_M_RD;
+    msg.len = length;
+    return i2c_m_sync_transfer(&s_i2c_master, &msg);
+}

--- a/DRIVERS/CDH_COMMON/src/driver_init.c
+++ b/DRIVERS/CDH_COMMON/src/driver_init.c
@@ -16,8 +16,6 @@
 
 #include "driver_init_private.h"
 
-struct i2c_m_sync_desc Mas_I2C_0;
-
 struct i2c_m_sync_desc Red_I2C_2;
 
 struct usart_sync_descriptor Debug_USART_0;
@@ -26,27 +24,7 @@ struct usart_sync_descriptor LVDS_USART_1;
 
 struct usart_sync_descriptor LVDS2_USART_2;
 
-void Mas_I2C_0_PORT_init(void)
-{
 
-	gpio_set_pin_function(PA4, MUX_PA4A_TWIHS0_TWCK0);
-
-	gpio_set_pin_function(PA3, MUX_PA3A_TWIHS0_TWD0);
-}
-
-void Mas_I2C_0_CLOCK_init(void)
-{
-	_pmc_enable_periph_clock(ID_TWIHS0);
-}
-
-void Mas_I2C_0_init(void)
-{
-	Mas_I2C_0_CLOCK_init();
-
-	i2c_m_sync_init(&Mas_I2C_0, TWIHS0);
-
-	Mas_I2C_0_PORT_init();
-}
 
 void Red_I2C_2_PORT_init(void)
 {
@@ -174,8 +152,6 @@ void system_init(void)
 
 	SPI0_init();
 	
-	Mas_I2C_0_init();
-
 	Red_I2C_2_init();
 
 	Debug_USART_0_init();

--- a/DRIVERS/CDH_COMMON/src/driver_init_private.h
+++ b/DRIVERS/CDH_COMMON/src/driver_init_private.h
@@ -7,7 +7,6 @@ extern "C" {
 #include <hal_i2c_m_sync.h>
 #include <hal_usart_sync.h>
 
-extern struct i2c_m_sync_desc Mas_I2C_0;
 
 extern struct i2c_m_sync_desc Red_I2C_2;
 
@@ -16,10 +15,6 @@ extern struct usart_sync_descriptor Debug_USART_0;
 extern struct usart_sync_descriptor LVDS_USART_1;
 
 extern struct usart_sync_descriptor LVDS2_USART_2;
-
-void Mas_I2C_0_CLOCK_init(void);
-void Mas_I2C_0_init(void);
-void Mas_I2C_0_PORT_init(void);
 
 void Red_I2C_2_CLOCK_init(void);
 void Red_I2C_2_init(void);

--- a/MIDDLEWARE/tinyprotocol/CMakeLists.txt
+++ b/MIDDLEWARE/tinyprotocol/CMakeLists.txt
@@ -1,0 +1,12 @@
+add_library(TINYPROTOCOL)
+
+target_sources(
+    TINYPROTOCOL
+    PRIVATE
+        tinyprotocol.c
+    PUBLIC
+        FILE_SET HEADERS
+        BASE_DIRS .
+        FILES
+            tinyprotocol.h
+)

--- a/MIDDLEWARE/tinyprotocol/tinyprotocol.c
+++ b/MIDDLEWARE/tinyprotocol/tinyprotocol.c
@@ -134,7 +134,7 @@ int16_t TINYPROTOCOL_RegisterTelecommand(uint8_t cmd, uint8_t size) {
     return ETINYPROTOCOL_SUCCESS;
 }
 
-int16_t TINYPROTOCOL_SendTelecommand(const struct TINYPROTOCOL_Config *cfg, uint8_t command, const uint8_t* buffer, uint8_t size) {
+int16_t TINYPROTOCOL_SendTelecommand(uint16_t slave, const struct TINYPROTOCOL_Config *cfg, uint8_t command, const uint8_t* buffer, uint8_t size) {
     if (size > TINYPROTOCOL_MAX_PAYLOAD_SIZE)
         return -ETINYPROTOCOL_INVALID_PAYLOAD_SIZE;
 
@@ -147,14 +147,14 @@ int16_t TINYPROTOCOL_SendTelecommand(const struct TINYPROTOCOL_Config *cfg, uint
     }
 
     tc_send_buffer_tmp[size + 2] = TINYPROTOCOL_CalculateCRC(&tc_send_buffer_tmp[1], size + 1);
-    return cfg->TINYPROTOCOL_WriteBuffer(tc_send_buffer_tmp, size + 3);
+    return cfg->TINYPROTOCOL_WriteBufferToSlave(slave, tc_send_buffer_tmp, size + 3);
 }
 
-int16_t TINYPROTOCOL_SendEmptyTelecommand(const struct TINYPROTOCOL_Config *cfg, uint8_t command) {
+int16_t TINYPROTOCOL_SendEmptyTelecommand(uint16_t slave, const struct TINYPROTOCOL_Config *cfg, uint8_t command) {
     tc_send_buffer_tmp[0] = TINYPROTOCOL_MAGIC;
     tc_send_buffer_tmp[1] = command;
     tc_send_buffer_tmp[2] = TINYPROTOCOL_CalculateCRC(&tc_send_buffer_tmp[1], 1);
-    return cfg->TINYPROTOCOL_WriteBuffer(tc_send_buffer_tmp, 3);
+    return cfg->TINYPROTOCOL_WriteBufferToSlave(slave, tc_send_buffer_tmp, 3);
 }
 
 int16_t TINYPROTOCOL_RegisterTelemetryChannel(uint8_t tlm_channel, const uint8_t* ptr, uint8_t size) {
@@ -173,7 +173,7 @@ int16_t TINYPROTOCOL_RegisterTelemetryChannel(uint8_t tlm_channel, const uint8_t
     return ETINYPROTOCOL_SUCCESS;
 }
 
-int16_t TINYPROTOCOL_SendTelemetryRequest(const struct TINYPROTOCOL_Config *cfg, uint8_t tlm_req) {
+int16_t TINYPROTOCOL_SendTelemetryRequest(uint16_t slave, const struct TINYPROTOCOL_Config *cfg, uint8_t tlm_req) {
     // Calculate crc and create buffer with proper content.
     uint8_t crc = TINYPROTOCOL_CalculateCRC(&tlm_req, 1);
 
@@ -181,7 +181,7 @@ int16_t TINYPROTOCOL_SendTelemetryRequest(const struct TINYPROTOCOL_Config *cfg,
     tlm_req |= 0x80;
     uint8_t buf[3] = {TINYPROTOCOL_MAGIC, tlm_req, crc};
 
-    return cfg->TINYPROTOCOL_WriteBuffer(buf, 3);
+    return cfg->TINYPROTOCOL_WriteBufferToSlave(slave, buf, 3);
 }
 
 int16_t TINYPROTOCOL_ReadNextTelemetryByte(uint8_t *byte) {

--- a/MIDDLEWARE/tinyprotocol/tinyprotocol.h
+++ b/MIDDLEWARE/tinyprotocol/tinyprotocol.h
@@ -36,6 +36,7 @@ struct TINYPROTOCOL_Config{
     int16_t (*TINYPROTOCOL_ProcessTelecommand)(uint8_t command, const uint8_t* buffer, uint8_t size);
     int16_t (*TINYPROTOCOL_ProcessTelemetryRequest)(uint8_t command);
     int16_t (*TINYPROTOCOL_WriteBuffer)(const uint8_t* buffer, uint8_t size);
+    int16_t (*TINYPROTOCOL_WriteBufferToSlave)(uint16_t slave, const uint8_t* buffer, uint8_t size);
 };
 
 int16_t TINYPROTOCOL_Initialize();
@@ -48,9 +49,9 @@ int16_t TINYPROTOCOL_ReadNextTelemetryByte(uint8_t *byte);
 int16_t TINYPROTOCOL_TelemetryBytesLeft();
 
 // Master functions 
-int16_t TINYPROTOCOL_SendTelecommand(const struct TINYPROTOCOL_Config *cfg, uint8_t tlcmd, const uint8_t* buffer, uint8_t size);
-int16_t TINYPROTOCOL_SendEmptyTelecommand(const struct TINYPROTOCOL_Config *cfg, uint8_t tlcmd);
-int16_t TINYPROTOCOL_SendTelemetryRequest(const struct TINYPROTOCOL_Config *cfg, uint8_t tlm_req);
+int16_t TINYPROTOCOL_SendTelecommand(uint16_t slave, const struct TINYPROTOCOL_Config *cfg, uint8_t tlcmd, const uint8_t* buffer, uint8_t size);
+int16_t TINYPROTOCOL_SendEmptyTelecommand(uint16_t slave, const struct TINYPROTOCOL_Config *cfg, uint8_t tlcmd);
+int16_t TINYPROTOCOL_SendTelemetryRequest(uint16_t slave, const struct TINYPROTOCOL_Config *cfg, uint8_t tlm_req);
 
 uint8_t TINYPROTOCOL_CalculateCRC(const uint8_t* buffer, uint8_t buffer_size);
 


### PR DESCRIPTION
## Description (tell us what you changes or added or removed please)
Adds a wrapper around I2C functionality for CDH samv71 board. Support master for now.

## How to test (if any tests done)
This was derived directly from commsdrive usecase #78 so I just tested the same way. This is basically a refactor

## Checklist
- [x] Code Compiles
- [x] Did you add any comments
- [x] Did you test it at all ?! Good Boy/Girl
