### PR TITLE
CDH: Switch to background openocd to avoid issues with restarting it constantly

### DIFF
--- a/Tools/remote_dev/build_and_upload.sh
+++ b/Tools/remote_dev/build_and_upload.sh
@@ -5,6 +5,8 @@ args=("$@")
 target=${args[0]:-none}
 
 source "$(dirname -- "$0")/config.sh"
+: "${ssh_host:?} ${ssh_port:?} ${ssh_user:?} ${tcl_port:?} ${gdb_port:?}"
+
 
 echo "Environment: Linux"
 echo "Target: $target"
@@ -45,19 +47,18 @@ EOF
   echo "====Upload(END)===="
 
   echo "====Flash(START)===="
+  # shellcheck disable=SC2087
   ssh -p "$ssh_port" "$ssh_user@$ssh_host" <<- EOF
-    cd remote_files
-    openocd -f cdh_openocd.cfg -c "telnet_port disabled" -c "tcl_port disabled" -c "gdb_port disabled" -c "program CDH.elf verify" -c reset -c shutdown
+    printf '%s\x1a' 'capture "program CDH.elf preverify verify reset"' | nc -q 1 127.0.0.1 $tcl_port | tr '\32' '\n'
+    echo "Done!"
 EOF
   echo "====Flash(END)===="
   echo
 
   echo "====Debug(START)===="
   # shellcheck disable=SC2087
-  ssh -L 127.0.0.1:$gdb_port:127.0.0.1:$gdb_port -p "$ssh_port" "$ssh_user@$ssh_host" <<- EOF
-    cd remote_files
-    openocd -f cdh_openocd.cfg -c "telnet_port disabled" -c "tcl_port disabled" -c "gdb_port $gdb_port" -c init -c "reset run" -c "echo ====Debug(READY)===="
-EOF
+  echo "Establishing background gdb tunnel (no further messages will be displayed)"
+  ssh -N -L "127.0.0.1:$gdb_port:127.0.0.1:$gdb_port" -p "$ssh_port" "$ssh_user@$ssh_host"
   echo "====Debug(END)===="
   echo
 }

--- a/Tools/remote_dev/config.sh
+++ b/Tools/remote_dev/config.sh
@@ -1,4 +1,6 @@
+# shellcheck disable=SC2034
 ssh_host=iris.alexkar598.dev
 ssh_port=42999
 ssh_user=remote
+tcl_port=9991
 gdb_port=9992

--- a/Tools/remote_dev/open_console.sh
+++ b/Tools/remote_dev/open_console.sh
@@ -5,6 +5,7 @@ args=("$@")
 target=${args[0]:-none}
 
 source "$(dirname -- "$0")/config.sh"
+: "${ssh_host:?} ${ssh_port:?} ${ssh_user:?}"
 
 echo "Environment: Linux"
 echo "Target: $target"

--- a/Tools/remote_dev/readme.MD
+++ b/Tools/remote_dev/readme.MD
@@ -22,8 +22,7 @@ On windows, cmake will not be invoked unless it is in the PATH.
 
 On CLion, remote development should be used in the following manner:
 1. (Windows only) Select `CDH (CMake)` and click the hammer icon to build the firmware.
-2. Select `CDH (Remote Upload + GDB)` and click the run icon. This step sometimes fails and crashes. If this happens, 
-rerun this step. You will know this step was successful when you see `====Debug(READY)====`. Do not stop this process
+2. Select `CDH (Remote Upload + GDB)` and click the run icon. Do not stop this process
 until you are done debugging.
 3. Select `CDH (Remote Logs)` and click the run icon. This step will fail if another user is looking at the logs.
 4. Select `CDH (Remote Debug)` and clich the debug icon. You should be able to use the debugging features of the IDE as


### PR DESCRIPTION
## Description (tell us what you changes or added or removed please)
OpenOCD is now started in the background by a systemd unit and we use the tcl port to send commands instead

## How to test (if any tests done)
Use remote dev

## Checklist
- [x] Code Compiles
- [x] Did you add any comments
- [x] Did you test it at all ?! Good Boy/Girl
