### PR TITLE
Tools: remote dev .cmd use bash over sh

### DIFF
--- a/Tools/remote_dev/build_and_upload.cmd
+++ b/Tools/remote_dev/build_and_upload.cmd
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S 2>/dev/null=2>NUL sh
+#!/usr/bin/env -S 2>/dev/null=2>NUL bash
 @goto batch 2>NUL;rm -f NUL
 
 source $(dirname -- "$0")/build_and_upload.sh

--- a/Tools/remote_dev/open_console.cmd
+++ b/Tools/remote_dev/open_console.cmd
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S 2>/dev/null=2>NUL sh
+#!/usr/bin/env -S 2>/dev/null=2>NUL bash
 @goto batch 2>NUL;rm -f NUL
 
 source $(dirname -- "$0")/open_console.sh

--- a/Tools/remote_dev/setup_key.cmd
+++ b/Tools/remote_dev/setup_key.cmd
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S 2>/dev/null=2>NUL sh
+#!/usr/bin/env -S 2>/dev/null=2>NUL bash
 @goto batch 2>NUL;rm -f NUL
 
 source $(dirname -- "$0")/setup_key.sh


### PR DESCRIPTION
This patch fixes "unknown cmd 'source'" errors on linux when running cmd files via CLion

## Description (tell us what you changes or added or removed please)
cmd files use sh instead of bash. On ubuntu 24 / CLion this causes this issue
<img width="1694" height="86" alt="image" src="https://github.com/user-attachments/assets/918fc765-b068-4655-ad39-aa5ade9b6dea" />


## How to test (if any tests done)
run any of the changed .cmd files in linux

## Checklist
- [x] Code Compiles
- [x] Did you add any comments
- [x] Did you test it at all ?! Good Boy/Girl
